### PR TITLE
Hotfix/#7 channel query without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.20
+
+- Fix channel query path without id
+
 ## 0.1.19
 
 - Fix loading message replies

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can sign up for a Stream account at https://getstream.io/chat/
 
 ```yaml
 dependencies:
- stream_chat: ^0.1.19
+ stream_chat: ^0.1.20
 ```
 
 You should then run `flutter packages get`

--- a/lib/src/api/channel.dart
+++ b/lib/src/api/channel.dart
@@ -451,8 +451,9 @@ class Channel {
   }) async {
     var path = "/channels/$type";
     if (id != null) {
-      path = "$path/$id/query";
+      path = "$path/$id";
     }
+    path = '$path/query';
 
     final payload = Map<String, dynamic>.from({
       "state": true,

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -2,4 +2,4 @@ import 'package:stream_chat/src/client.dart';
 
 /// Current package version
 /// Used in [Client] to build the `x-stream-client` header
-const PACKAGE_VERSION = '0.1.19';
+const PACKAGE_VERSION = '0.1.20';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_chat
 homepage: https://github.com/GetStream/stream-chat-dart
 description: The official Dart client for Stream Chat, a service for building chat applications.
-version: 0.1.19
+version: 0.1.20
 
 environment:
   sdk: ">=2.2.2 <3.0.0"

--- a/test/src/api/channel_test.dart
+++ b/test/src/api/channel_test.dart
@@ -529,7 +529,7 @@ void main() {
             'presence': true,
           };
 
-          when(mockDio.post<String>('/channels/messaging', data: options))
+          when(mockDio.post<String>('/channels/messaging/query', data: options))
               .thenAnswer((_) async {
             return Response(data: r'''
             {
@@ -822,7 +822,8 @@ void main() {
 
           final response = await channelClient.query(options: options);
 
-          verify(mockDio.post<String>('/channels/messaging', data: options))
+          verify(mockDio.post<String>('/channels/messaging/query',
+                  data: options))
               .called(1);
           expect(channelClient.id, response.channel.id);
           expect(channelClient.cid, response.channel.cid);
@@ -1160,7 +1161,7 @@ void main() {
           'presence': false,
         };
 
-        when(mockDio.post<String>('/channels/messaging', data: options))
+        when(mockDio.post<String>('/channels/messaging/query', data: options))
             .thenAnswer((_) async => Response(data: r'''
             {
             "channel": {
@@ -1451,7 +1452,7 @@ void main() {
 
         final response = await channelClient.create();
 
-        verify(mockDio.post<String>('/channels/messaging', data: options))
+        verify(mockDio.post<String>('/channels/messaging/query', data: options))
             .called(1);
         expect(channelClient.id, response.channel.id);
         expect(channelClient.cid, response.channel.cid);
@@ -1475,7 +1476,7 @@ void main() {
           'presence': true,
         };
 
-        when(mockDio.post<String>('/channels/messaging', data: options))
+        when(mockDio.post<String>('/channels/messaging/query', data: options))
             .thenAnswer((_) async => Response(data: r'''
             {
             "channel": {
@@ -1766,7 +1767,7 @@ void main() {
 
         final response = await channelClient.watch({'presence': true});
 
-        verify(mockDio.post<String>('/channels/messaging', data: options))
+        verify(mockDio.post<String>('/channels/messaging/query', data: options))
             .called(1);
         expect(channelClient.id, response.channel.id);
         expect(channelClient.cid, response.channel.cid);


### PR DESCRIPTION
Fix channel query path without a channel id
Fix for https://github.com/GetStream/stream-chat-flutter/issues/7