### PR TITLE
add connection_id to send message body

### DIFF
--- a/lib/src/api/channel.dart
+++ b/lib/src/api/channel.dart
@@ -126,6 +126,7 @@ class Channel {
     final response = await _client.post(
       "$_channelURL/message",
       data: {
+        "connection_id": _client.connectionId,
         "message": message
             .copyWith(
               id: messageId,

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -121,6 +121,9 @@ class Client {
   final ValueNotifier<ConnectionStatus> wsConnectionStatus =
       ValueNotifier(null);
 
+  /// The id of the current websocket connection
+  String get connectionId => _connectionId;
+
   String _token;
   bool _anonymous = false;
   String _connectionId;

--- a/test/src/api/channel_test.dart
+++ b/test/src/api/channel_test.dart
@@ -33,14 +33,18 @@ void main() {
           id: 'test',
         );
 
-        when(mockDio.post<String>('/channels/messaging/testid/message',
-                data: {'message': message.toJson()}))
-            .thenAnswer((_) async => Response(data: '{}', statusCode: 200));
+        when(mockDio.post<String>('/channels/messaging/testid/message', data: {
+          'message': message.toJson(),
+          'connection_id': null,
+        })).thenAnswer((_) async => Response(data: '{}', statusCode: 200));
 
         await channelClient.sendMessage(message);
 
-        verify(mockDio.post<String>('/channels/messaging/testid/message',
-            data: {'message': message.toJson()})).called(1);
+        verify(
+            mockDio.post<String>('/channels/messaging/testid/message', data: {
+          'message': message.toJson(),
+          'connection_id': null,
+        })).called(1);
       });
 
       test('markRead', () async {


### PR DESCRIPTION
Without connection_id the user online status in the event object is always false