### PR TITLE
(Experimental) Enable web support for chat

### DIFF
--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -27,8 +27,6 @@ part 'models.part.dart';
 part 'offline_storage.g.dart';
 
 Future<MoorIsolate> _createMoorIsolate(String userId) async {
-  WidgetsFlutterBinding.ensureInitialized();
-
   final receivePort = ReceivePort();
   await Isolate.spawn(
     _startBackground,
@@ -50,6 +48,7 @@ void _startBackground(_IsolateStartRequest request) {
 
 /// Gets a new instance of the database running on a background isolate
 Future<OfflineStorage> connectDatabase(User user, Logger logger) async {
+  WidgetsFlutterBinding.ensureInitialized();
   if(kIsWeb) {
     return OfflineStorage(
       user.id,

--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -7,7 +7,7 @@ import 'package:moor/isolate.dart';
 import 'package:moor/moor.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
-import 'package:stream_chat/src/db/shared_database.dart';
+import 'package:stream_chat/src/db/shared/shared_database.dart';
 import 'package:stream_chat/src/models/event.dart';
 import 'package:stream_chat/src/models/own_user.dart';
 

--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -33,7 +33,7 @@ Future<MoorIsolate> _createMoorIsolate(String userId) async {
   final receivePort = ReceivePort();
   await Isolate.spawn(
     _startBackground,
-    _IsolateStartRequest(receivePort.sendPort, path),
+    _IsolateStartRequest(receivePort.sendPort, path, 'db_$userId.sqlite'),
   );
 
   return (await receivePort.first as MoorIsolate);
@@ -41,7 +41,7 @@ Future<MoorIsolate> _createMoorIsolate(String userId) async {
 
 void _startBackground(_IsolateStartRequest request) {
   final executor = LazyDatabase(() async {
-    return SharedDB.constructDatabase(request.targetPath);
+    return SharedDB.constructDatabase(request.targetPath, request.dbName);
   });
   final moorIsolate = MoorIsolate.inCurrent(
     () => DatabaseConnection.fromExecutor(executor),
@@ -65,8 +65,9 @@ Future<OfflineStorage> connectDatabase(User user, Logger logger) async {
 class _IsolateStartRequest {
   final SendPort sendMoorIsolate;
   final String targetPath;
+  final String dbName;
 
-  _IsolateStartRequest(this.sendMoorIsolate, this.targetPath);
+  _IsolateStartRequest(this.sendMoorIsolate, this.targetPath, this.dbName);
 }
 
 LazyDatabase _openConnection(String userId) {
@@ -74,7 +75,7 @@ LazyDatabase _openConnection(String userId) {
   return LazyDatabase(() async {
     final dir = await getApplicationDocumentsDirectory();
     final path = p.join(dir.path, 'db_$userId.sqlite');
-    return SharedDB.constructDatabase(path);
+    return SharedDB.constructDatabase(path, 'db_$userId.sqlite');
   });
 }
 

--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -25,22 +25,9 @@ part 'offline_storage.g.dart';
 /// Gets a new instance of the database running on a background isolate
 Future<OfflineStorage> connectDatabase(User user, Logger logger) async {
   WidgetsFlutterBinding.ensureInitialized();
-  if(kIsWeb) {
-    return OfflineStorage(
-      user.id,
-      logger,
-    );
-  } else {
-    logger.info('Connecting on background isolate');
-    final isolate = await SharedDB.createMoorIsolate(user.id);
-    final connection = await isolate.connect();
-    return OfflineStorage.connect(
-      connection,
-      user.id,
-      isolate,
-      logger,
-    );
-  }
+  return SharedDB.constructOfflineStorage(
+    userId: user.id,
+    logger: logger,);
 }
 
 LazyDatabase _openConnection(String userId) {

--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 import 'dart:isolate';
 
 import 'package:flutter/material.dart' show WidgetsFlutterBinding;

--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:isolate';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' show WidgetsFlutterBinding;
 import 'package:logging/logging.dart';
 import 'package:moor/isolate.dart';
@@ -49,15 +50,22 @@ void _startBackground(_IsolateStartRequest request) {
 
 /// Gets a new instance of the database running on a background isolate
 Future<OfflineStorage> connectDatabase(User user, Logger logger) async {
-  logger.info('Connecting on background isolate');
-  final isolate = await _createMoorIsolate(user.id);
-  final connection = await isolate.connect();
-  return OfflineStorage.connect(
-    connection,
-    user.id,
-    isolate,
-    logger,
-  );
+  if(kIsWeb) {
+    return OfflineStorage(
+      user.id,
+      logger,
+    );
+  } else {
+    logger.info('Connecting on background isolate');
+    final isolate = await _createMoorIsolate(user.id);
+    final connection = await isolate.connect();
+    return OfflineStorage.connect(
+      connection,
+      user.id,
+      isolate,
+      logger,
+    );
+  }
 }
 
 class _IsolateStartRequest {

--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -6,9 +6,9 @@ import 'package:flutter/material.dart' show WidgetsFlutterBinding;
 import 'package:logging/logging.dart';
 import 'package:moor/isolate.dart';
 import 'package:moor/moor.dart';
-import 'package:moor/ffi.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:stream_chat/src/db/shared_database.dart';
 import 'package:stream_chat/src/models/event.dart';
 import 'package:stream_chat/src/models/own_user.dart';
 
@@ -42,7 +42,7 @@ Future<MoorIsolate> _createMoorIsolate(String userId) async {
 
 void _startBackground(_IsolateStartRequest request) {
   final executor = LazyDatabase(() async {
-    return VmDatabase(File(request.targetPath));
+    return SharedDB.constructDatabase(request.targetPath);
   });
   final moorIsolate = MoorIsolate.inCurrent(
     () => DatabaseConnection.fromExecutor(executor),
@@ -75,8 +75,7 @@ LazyDatabase _openConnection(String userId) {
   return LazyDatabase(() async {
     final dir = await getApplicationDocumentsDirectory();
     final path = p.join(dir.path, 'db_$userId.sqlite');
-    final file = File(path);
-    return VmDatabase(file);
+    return SharedDB.constructDatabase(path);
   });
 }
 

--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -27,7 +27,8 @@ Future<OfflineStorage> connectDatabase(User user, Logger logger) async {
   WidgetsFlutterBinding.ensureInitialized();
   return SharedDB.constructOfflineStorage(
     userId: user.id,
-    logger: logger,);
+    logger: logger,
+  );
 }
 
 LazyDatabase _openConnection(String userId) {

--- a/lib/src/db/shared/native_db.dart
+++ b/lib/src/db/shared/native_db.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+import 'package:moor/ffi.dart';
+
+class SharedDB {
+  static constructDatabase(doc) {
+    return VmDatabase(File(doc));
+  }
+}

--- a/lib/src/db/shared/native_db.dart
+++ b/lib/src/db/shared/native_db.dart
@@ -1,8 +1,13 @@
 import 'dart:io';
 import 'package:moor/ffi.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
 
 class SharedDB {
-  static constructDatabase(doc, dbName) {
-    return VmDatabase(File(doc));
+  static constructDatabase(dbName) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final path = join(dir.path, dbName);
+
+    return VmDatabase(File(path));
   }
 }

--- a/lib/src/db/shared/native_db.dart
+++ b/lib/src/db/shared/native_db.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'package:moor/ffi.dart';
 
 class SharedDB {
-  static constructDatabase(doc) {
+  static constructDatabase(doc, dbName) {
     return VmDatabase(File(doc));
   }
 }

--- a/lib/src/db/shared/native_db.dart
+++ b/lib/src/db/shared/native_db.dart
@@ -1,14 +1,46 @@
 import 'dart:io';
+import 'dart:isolate';
 import 'package:flutter/material.dart';
 import 'package:moor/ffi.dart';
+import 'package:moor/isolate.dart';
+import 'package:moor/moor.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
 class SharedDB {
-  static constructDatabase(dbName) async {
-    final dir = await getApplicationDocumentsDirectory();
-    final path = join(dir.path, dbName);
-
+  static constructDatabase(path) async {
     return VmDatabase(File(path));
   }
+
+  static Future<MoorIsolate> createMoorIsolate(String userId) async {
+    WidgetsFlutterBinding.ensureInitialized();
+    final dir = await getApplicationDocumentsDirectory();
+    final path = join(dir.path, 'db_$userId.sqlite');
+
+    final receivePort = ReceivePort();
+    await Isolate.spawn(
+      startBackground,
+      _IsolateStartRequest(receivePort.sendPort, path),
+    );
+
+    return (await receivePort.first as MoorIsolate);
+  }
+
+  static void startBackground(_IsolateStartRequest request) {
+    final executor = LazyDatabase(() async {
+      return VmDatabase(File(request.targetPath));
+    });
+    final moorIsolate = MoorIsolate.inCurrent(
+          () => DatabaseConnection.fromExecutor(executor),
+    );
+    request.sendMoorIsolate.send(moorIsolate);
+  }
+
+}
+
+class _IsolateStartRequest {
+  final SendPort sendMoorIsolate;
+  final String targetPath;
+
+  _IsolateStartRequest(this.sendMoorIsolate, this.targetPath);
 }

--- a/lib/src/db/shared/native_db.dart
+++ b/lib/src/db/shared/native_db.dart
@@ -6,7 +6,6 @@ import 'package:path_provider/path_provider.dart';
 
 class SharedDB {
   static constructDatabase(dbName) async {
-    WidgetsFlutterBinding.ensureInitialized();
     final dir = await getApplicationDocumentsDirectory();
     final path = join(dir.path, dbName);
 

--- a/lib/src/db/shared/native_db.dart
+++ b/lib/src/db/shared/native_db.dart
@@ -1,10 +1,12 @@
 import 'dart:io';
+import 'package:flutter/material.dart';
 import 'package:moor/ffi.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
 class SharedDB {
   static constructDatabase(dbName) async {
+    WidgetsFlutterBinding.ensureInitialized();
     final dir = await getApplicationDocumentsDirectory();
     final path = join(dir.path, dbName);
 

--- a/lib/src/db/shared/native_db.dart
+++ b/lib/src/db/shared/native_db.dart
@@ -9,8 +9,11 @@ import 'package:path_provider/path_provider.dart';
 import 'package:stream_chat/src/db/offline_storage.dart';
 
 class SharedDB {
-  static constructDatabase(path) async {
-    return VmDatabase(File(path));
+  static constructDatabase(dbName) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final path = join(dir.path, dbName);
+    final file = File(path);
+    return VmDatabase(file);
   }
 
   static Future<MoorIsolate> createMoorIsolate(String userId) async {

--- a/lib/src/db/shared/shared_database.dart
+++ b/lib/src/db/shared/shared_database.dart
@@ -1,0 +1,3 @@
+export 'unsupported_db.dart'
+    if (dart.library.io) 'native_db.dart' // implementation using dart:io
+    if (dart.library.html) 'web_db.dart'; // implementation using dart:html|js

--- a/lib/src/db/shared/unsupported_db.dart
+++ b/lib/src/db/shared/unsupported_db.dart
@@ -1,5 +1,5 @@
 class SharedDB {
-  static constructDatabase(doc, dbName) {
+  static constructDatabase(dbName) async {
     print('Unsupported Platform');
     return null;
   }

--- a/lib/src/db/shared/unsupported_db.dart
+++ b/lib/src/db/shared/unsupported_db.dart
@@ -3,4 +3,8 @@ class SharedDB {
     print('Unsupported Platform');
     return null;
   }
+
+  static createMoorIsolate(userId) {}
+
+  static startBackground(request) {}
 }

--- a/lib/src/db/shared/unsupported_db.dart
+++ b/lib/src/db/shared/unsupported_db.dart
@@ -7,4 +7,6 @@ class SharedDB {
   static createMoorIsolate(userId) {}
 
   static startBackground(request) {}
+
+  static constructOfflineStorage({userId, logger}) {}
 }

--- a/lib/src/db/shared/unsupported_db.dart
+++ b/lib/src/db/shared/unsupported_db.dart
@@ -1,5 +1,5 @@
 class SharedDB {
-  static constructDatabase(doc) {
+  static constructDatabase(doc, dbName) {
     print('Unsupported Platform');
     return null;
   }

--- a/lib/src/db/shared/unsupported_db.dart
+++ b/lib/src/db/shared/unsupported_db.dart
@@ -1,0 +1,6 @@
+class SharedDB {
+  static constructDatabase(doc) {
+    print('Unsupported Platform');
+    return null;
+  }
+}

--- a/lib/src/db/shared/web_db.dart
+++ b/lib/src/db/shared/web_db.dart
@@ -6,8 +6,10 @@ class SharedDB {
     return WebDatabase(dbName);
   }
 
-  static Future<OfflineStorage> constructOfflineStorage(
-      {connection, userId, isolate, logger}) async {
+  static Future<OfflineStorage> constructOfflineStorage({
+    userId,
+    logger,
+  }) async {
     return OfflineStorage(
       userId,
       logger,

--- a/lib/src/db/shared/web_db.dart
+++ b/lib/src/db/shared/web_db.dart
@@ -1,0 +1,7 @@
+import 'package:moor/moor_web.dart';
+
+class SharedDB {
+  static constructDatabase(path) {
+    return WebDatabase(path);
+  }
+}

--- a/lib/src/db/shared/web_db.dart
+++ b/lib/src/db/shared/web_db.dart
@@ -1,7 +1,16 @@
 import 'package:moor/moor_web.dart';
+import 'package:stream_chat/src/db/offline_storage.dart';
 
 class SharedDB {
   static constructDatabase(dbName) async {
     return WebDatabase(dbName);
+  }
+
+  static Future<OfflineStorage> constructOfflineStorage(
+      {connection, userId, isolate, logger}) async {
+    return OfflineStorage(
+      userId,
+      logger,
+    );
   }
 }

--- a/lib/src/db/shared/web_db.dart
+++ b/lib/src/db/shared/web_db.dart
@@ -1,7 +1,7 @@
 import 'package:moor/moor_web.dart';
 
 class SharedDB {
-  static constructDatabase(path, dbName) {
+  static constructDatabase(dbName) async {
     return WebDatabase(dbName);
   }
 }

--- a/lib/src/db/shared/web_db.dart
+++ b/lib/src/db/shared/web_db.dart
@@ -1,7 +1,7 @@
 import 'package:moor/moor_web.dart';
 
 class SharedDB {
-  static constructDatabase(path) {
-    return WebDatabase(path);
+  static constructDatabase(path, dbName) {
+    return WebDatabase(dbName);
   }
 }

--- a/lib/src/db/shared_database.dart
+++ b/lib/src/db/shared_database.dart
@@ -1,3 +1,0 @@
-export 'shared/unsupported_db.dart'
-    if (dart.library.io) 'src/db/shared/native_db.dart' // implementation using dart:io
-    if (dart.library.html) 'src/db/shared/web_db.dart'; // implementation using dart:html|js

--- a/lib/src/db/shared_database.dart
+++ b/lib/src/db/shared_database.dart
@@ -1,0 +1,3 @@
+export 'shared/unsupported_db.dart'
+    if (dart.library.io) 'src/db/shared/native_db.dart' // implementation using dart:io
+    if (dart.library.html) 'src/db/shared/web_db.dart'; // implementation using dart:html|js

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,6 @@ environment:
   sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
   json_annotation: ^3.0.1
   shared_preferences: ^0.5.7+3
   logging: ^0.11.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
   sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
   json_annotation: ^3.0.1
   shared_preferences: ^0.5.7+3
   logging: ^0.11.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   path: ^1.6.4
   rxdart: ^0.24.1
   collection: ^1.14.12
+  sqlite3_flutter_libs: ^0.2.0
 
 dev_dependencies:
   build_runner: ^1.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   path: ^1.6.4
   rxdart: ^0.24.1
   collection: ^1.14.12
-  sqlite3_flutter_libs: ^0.2.0
 
 dev_dependencies:
   build_runner: ^1.10.0


### PR DESCRIPTION
# PR Details

## CLA

- [ ✓] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ✓] The code changes follow best practices
- [ ✓] Code changes are tested (add some information if not applicable)

## Description of the pull request

This PR adds experimental support for Flutter web.

A SharedDatabase is used for isolating imports and calling web and native calls individually.
Since isolates are not supported and workarounds are currently not well tested, the same isolate is used.