### PR TITLE
Cleaned up Serialization on extra_data

### DIFF
--- a/lib/src/models/attachment.dart
+++ b/lib/src/models/attachment.dart
@@ -106,11 +106,11 @@ class Attachment {
   /// Create a new instance from a json
   factory Attachment.fromJson(Map<String, dynamic> json) {
     return _$AttachmentFromJson(
-        Serialization.moveKeysToRoot(json, topLevelFields));
+        Serialization.moveToExtraDataFromRoot(json, topLevelFields));
   }
 
   /// Serialize to json
-  Map<String, dynamic> toJson() => Serialization.moveKeysToMapInPlace(
+  Map<String, dynamic> toJson() => Serialization.moveFromExtraDataToRoot(
       _$AttachmentToJson(this), topLevelFields);
 
   Attachment copyWith({

--- a/lib/src/models/channel_model.dart
+++ b/lib/src/models/channel_model.dart
@@ -100,12 +100,12 @@ class ChannelModel {
   /// Create a new instance from a json
   factory ChannelModel.fromJson(Map<String, dynamic> json) {
     return _$ChannelModelFromJson(
-        Serialization.moveKeysToRoot(json, topLevelFields));
+        Serialization.moveToExtraDataFromRoot(json, topLevelFields));
   }
 
   /// Serialize to json
   Map<String, dynamic> toJson() {
-    return Serialization.moveKeysToMapInPlace(
+    return Serialization.moveFromExtraDataToRoot(
       _$ChannelModelToJson(this),
       topLevelFields,
     );

--- a/lib/src/models/event.dart
+++ b/lib/src/models/event.dart
@@ -138,6 +138,6 @@ class EventChannel extends ChannelModel {
   /// Create a new instance from a json
   factory EventChannel.fromJson(Map<String, dynamic> json) {
     return _$EventChannelFromJson(
-        Serialization.moveKeysToRoot(json, topLevelFields));
+        Serialization.moveToExtraDataFromRoot(json, topLevelFields));
   }
 }

--- a/lib/src/models/message.dart
+++ b/lib/src/models/message.dart
@@ -167,12 +167,12 @@ class Message {
   });
 
   /// Create a new instance from a json
-  factory Message.fromJson(Map<String, dynamic> json) =>
-      _$MessageFromJson(Serialization.moveKeysToRoot(json, topLevelFields));
+  factory Message.fromJson(Map<String, dynamic> json) => _$MessageFromJson(
+      Serialization.moveToExtraDataFromRoot(json, topLevelFields));
 
   /// Serialize to json
-  Map<String, dynamic> toJson() =>
-      Serialization.moveKeysToMapInPlace(_$MessageToJson(this), topLevelFields);
+  Map<String, dynamic> toJson() => Serialization.moveFromExtraDataToRoot(
+      _$MessageToJson(this), topLevelFields);
 
   /// Creates a copy of [Message] with specified attributes overridden.
   Message copyWith({
@@ -241,7 +241,7 @@ class TranslatedMessage extends Message {
   /// Create a new instance from a json
   factory TranslatedMessage.fromJson(Map<String, dynamic> json) {
     return _$TranslatedMessageFromJson(
-      Serialization.moveKeysToRoot(json, topLevelFields),
+      Serialization.moveToExtraDataFromRoot(json, topLevelFields),
     );
   }
 }

--- a/lib/src/models/own_user.dart
+++ b/lib/src/models/own_user.dart
@@ -71,13 +71,13 @@ class OwnUser extends User {
   /// Create a new instance from a json
   factory OwnUser.fromJson(Map<String, dynamic> json) {
     return _$OwnUserFromJson(
-        Serialization.moveKeysToRoot(json, topLevelFields));
+        Serialization.moveToExtraDataFromRoot(json, topLevelFields));
   }
 
   /// Serialize to json
   @override
   Map<String, dynamic> toJson() {
-    return Serialization.moveKeysToMapInPlace(
+    return Serialization.moveFromExtraDataToRoot(
         _$OwnUserToJson(this), topLevelFields);
   }
 }

--- a/lib/src/models/reaction.dart
+++ b/lib/src/models/reaction.dart
@@ -57,12 +57,12 @@ class Reaction {
   /// Create a new instance from a json
   factory Reaction.fromJson(Map<String, dynamic> json) {
     return _$ReactionFromJson(
-        Serialization.moveKeysToRoot(json, topLevelFields));
+        Serialization.moveToExtraDataFromRoot(json, topLevelFields));
   }
 
   /// Serialize to json
   Map<String, dynamic> toJson() {
-    return Serialization.moveKeysToMapInPlace(
+    return Serialization.moveFromExtraDataToRoot(
         _$ReactionToJson(this), topLevelFields);
   }
 }

--- a/lib/src/models/serialization.dart
+++ b/lib/src/models/serialization.dart
@@ -18,17 +18,15 @@ class Serialization {
     Map<String, dynamic> json,
     List<String> topLevelFields,
   ) {
-    final extraDataFields = Map<String, dynamic>.from(json)
+    final extraDataMap = Map<String, dynamic>.from(json)
       ..removeWhere(
         (key, value) => topLevelFields.contains(key),
       );
-    final rootFields = json..remove(extraDataFields.keys);
-    return {
-      ...rootFields,
-      ...{
-        'extra_data': extraDataFields,
-      },
-    };
+    final rootFields = json..remove(extraDataMap.keys);
+    return rootFields
+      ..addAll({
+        'extra_data': extraDataMap,
+      });
   }
 
   /// Takes values in `extra_data` key and puts them on the root level of the json map

--- a/lib/src/models/serialization.dart
+++ b/lib/src/models/serialization.dart
@@ -13,44 +13,35 @@ class Serialization {
     return users?.map((u) => u.id)?.toList();
   }
 
-  /// Takes values in `extra_data` key and puts them on the root level of the json map
-  static Map<String, dynamic> moveKeysToRoot(
+  /// Takes unknown json keys and puts them in the `extra_data` key
+  static Map<String, dynamic> moveToExtraDataFromRoot(
     Map<String, dynamic> json,
     List<String> topLevelFields,
   ) {
-    if (json == null) {
-      return json;
-    }
-    var clone = Map<String, dynamic>.from(json);
-    clone['extra_data'] = <String, dynamic>{};
-
-    json?.keys?.forEach((key) {
-      if (!topLevelFields.contains(key)) {
-        clone['extra_data'][key] = clone.remove(key);
-      }
-    });
-
-    return clone;
+    final rootFields = Map<String, dynamic>.from(json)
+      ..removeWhere(
+        (key, value) => !topLevelFields.contains(key),
+      );
+    final extraDataFields = Map<String, dynamic>.from(json)
+      ..removeWhere(
+        (key, value) => topLevelFields.contains(key),
+      );
+    return {
+      ...rootFields,
+      ...{
+        'extra_data': extraDataFields,
+      },
+    };
   }
 
-  /// Takes unknown json keys and puts them in the `extra_data` key
-  static Map<String, dynamic> moveKeysToMapInPlace(
-    Map<String, dynamic> intermediateMap,
+  /// Takes values in `extra_data` key and puts them on the root level of the json map
+  static Map<String, dynamic> moveFromExtraDataToRoot(
+    Map<String, dynamic> json,
     List<String> topLevelFields,
   ) {
-    if (intermediateMap == null) {
-      return intermediateMap;
-    }
-
-    var clone = Map<String, dynamic>.from(intermediateMap);
-    Map<String, dynamic> extraData = clone.remove('extra_data');
-
-    extraData?.keys?.forEach((key) {
-      if (!topLevelFields.contains(key)) {
-        clone[key] = extraData[key];
-      }
-    });
-
-    return clone;
+    return {
+      ...json,
+      if (json.containsKey('extra_data')) ...json['extra_data'],
+    };
   }
 }

--- a/lib/src/models/serialization.dart
+++ b/lib/src/models/serialization.dart
@@ -18,11 +18,14 @@ class Serialization {
     Map<String, dynamic> json,
     List<String> topLevelFields,
   ) {
+    if (json == null) return null;
+
     final extraDataMap = Map<String, dynamic>.from(json)
       ..removeWhere(
         (key, value) => topLevelFields.contains(key),
       );
-    final rootFields = json..remove(extraDataMap.keys);
+    final rootFields = json
+      ..removeWhere((key, value) => extraDataMap.keys.contains(key));
     return rootFields
       ..addAll({
         'extra_data': extraDataMap,

--- a/lib/src/models/serialization.dart
+++ b/lib/src/models/serialization.dart
@@ -18,14 +18,11 @@ class Serialization {
     Map<String, dynamic> json,
     List<String> topLevelFields,
   ) {
-    final rootFields = Map<String, dynamic>.from(json)
-      ..removeWhere(
-        (key, value) => !topLevelFields.contains(key),
-      );
     final extraDataFields = Map<String, dynamic>.from(json)
       ..removeWhere(
         (key, value) => topLevelFields.contains(key),
       );
+    final rootFields = json..remove(extraDataFields.keys);
     return {
       ...rootFields,
       ...{

--- a/lib/src/models/serialization.dart
+++ b/lib/src/models/serialization.dart
@@ -41,7 +41,7 @@ class Serialization {
   ) {
     return {
       ...json,
-      if (json.containsKey('extra_data')) ...json['extra_data'],
+      if (json['extra_data'] != null) ...json['extra_data'],
     };
   }
 }

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -86,12 +86,13 @@ class User {
 
   /// Create a new instance from a json
   factory User.fromJson(Map<String, dynamic> json) {
-    return _$UserFromJson(Serialization.moveKeysToRoot(json, topLevelFields));
+    return _$UserFromJson(
+        Serialization.moveToExtraDataFromRoot(json, topLevelFields));
   }
 
   /// Serialize to json
   Map<String, dynamic> toJson() {
-    return Serialization.moveKeysToMapInPlace(
+    return Serialization.moveFromExtraDataToRoot(
         _$UserToJson(this), topLevelFields);
   }
 

--- a/test/src/models/serialization_test.dart
+++ b/test/src/models/serialization_test.dart
@@ -4,7 +4,7 @@ import 'package:stream_chat/src/models/serialization.dart';
 void main() {
   group('src/models/serialization', () {
     test('should move unknown keys from root to dedicate property', () {
-      final result = Serialization.moveKeysToRoot({
+      final result = Serialization.moveToExtraDataFromRoot({
         'prop1': 'test',
         'prop2': 123,
         'prop3': true,
@@ -23,7 +23,7 @@ void main() {
     });
 
     test('should have empty extraData', () {
-      final result = Serialization.moveKeysToRoot({
+      final result = Serialization.moveToExtraDataFromRoot({
         'prop1': 'test',
         'prop2': 123,
         'prop3': true,
@@ -42,7 +42,7 @@ void main() {
     });
 
     test('should return null', () {
-      final result = Serialization.moveKeysToRoot(null, [
+      final result = Serialization.moveToExtraDataFromRoot(null, [
         'prop1',
         'prop2',
       ]);


### PR DESCRIPTION
# Submit a pull request



## CLA

- [ ☑️] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [☑️ ] The code changes follow best practices
- [☑️ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
The methods for going to/from flattened json to json with `extra_data` seemed to be mixed up. 

- Renamed the methods to be more explicit about their functionality
- The documentation for the methods were swapped so fixed that
- Simplified the implementation of both methods
- Migrated the use of the previous method names to the new method names

I just want to confirm whether I'm understanding the desired behavior to make sure I didn't do this backwards:

Backend -> Client
1. Stream backend sends to the client in a flattened map with no nested `extra_data` field
2. Upon receipt we keep the `topLevelFields` at the root of the object moving all other fields to the `extra_data` field 

Client -> Backend 
1. Merge the extra_data fields back into the root to send to the backend
 