### PR TITLE
copy ownreactions on message update

### DIFF
--- a/lib/src/api/channel.dart
+++ b/lib/src/api/channel.dart
@@ -999,7 +999,17 @@ class ChannelClientState {
   void _listenMessageUpdated() {
     _channel.on(EventType.messageUpdated).listen((event) {
       final message = event.message;
-      addMessage(message);
+
+      final oldMessageIndex =
+          messages.indexWhere((element) => element.id == message.id);
+      if (oldMessageIndex != -1) {
+        final oldMessage = messages[oldMessageIndex];
+        addMessage(message.copyWith(
+          ownReactions: oldMessage.ownReactions,
+        ));
+      } else {
+        addMessage(message);
+      }
     });
   }
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1035,7 +1035,9 @@ class Client {
         UpdateMessageResponse.fromJson,
       );
 
-      channel?.state?.addMessage(updateMessageResponse?.message);
+      channel?.state?.addMessage(updateMessageResponse?.message?.copyWith(
+        ownReactions: message.ownReactions,
+      ));
 
       return updateMessageResponse;
     }).catchError((error) {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Mainly because the backend returns the message with empty `ownReactions`, so we just copy them from the message we already have in memory