### PR TITLE
limit to 1 queryChannels with same params

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -529,6 +529,10 @@ class Client {
     }
   }
 
+  String _asMap(sort) {
+    return sort?.map((s) => s.toJson());
+  }
+
   final _queryChannelsStreams = <String, Stream<List<Channel>>>{};
 
   /// Requests channels with a given query.
@@ -541,7 +545,7 @@ class Client {
     bool onlyOffline = false,
   }) {
     final hash = base64.encode(utf8.encode(
-        '$filter${sort?.map((s) => s.toJson())}$options${paginationParams?.toJson()}$messageLimit$onlyOffline'));
+        '$filter${_asMap(sort)}$options${paginationParams?.toJson()}$messageLimit$onlyOffline'));
 
     if (_queryChannelsStreams.containsKey(hash)) {
       return _queryChannelsStreams[hash];

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -530,7 +530,7 @@ class Client {
   }
 
   String _asMap(sort) {
-    return sort?.map((s) => s.toJson());
+    return sort?.map((s) => s.toJson().toString())?.join('');
   }
 
   final _queryChannelsStreams = <String, Stream<List<Channel>>>{};
@@ -546,7 +546,8 @@ class Client {
   }) {
     final hash = base64.encode(utf8.encode(
         '$filter${_asMap(sort)}$options${paginationParams?.toJson()}$messageLimit$onlyOffline'));
-
+    print(
+        '$filter${_asMap(sort)}$options${paginationParams?.toJson()}$messageLimit$onlyOffline');
     if (_queryChannelsStreams.containsKey(hash)) {
       return _queryChannelsStreams[hash];
     }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -541,7 +541,7 @@ class Client {
     bool onlyOffline = false,
   }) {
     final hash = base64.encode(utf8.encode(
-        '$filter${sort.map((s) => s.toJson())}$options${paginationParams.toJson()}$messageLimit$onlyOffline'));
+        '$filter${sort?.map((s) => s.toJson())}$options${paginationParams?.toJson()}$messageLimit$onlyOffline'));
 
     if (_queryChannelsStreams.containsKey(hash)) {
       return _queryChannelsStreams[hash];

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -564,11 +564,11 @@ class Client {
   }
 
   Stream<List<Channel>> _doQueryChannels({
-    Map<String, dynamic> filter,
-    List<SortOption> sort,
-    Map<String, dynamic> options,
+    @required Map<String, dynamic> filter,
+    @required List<SortOption> sort,
+    @required Map<String, dynamic> options,
+    @required int messageLimit,
     PaginationParams paginationParams = const PaginationParams(limit: 10),
-    int messageLimit,
     bool onlyOffline = false,
   }) async* {
     logger.info('Query channel start');

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -547,7 +547,7 @@ class Client {
       return _queryChannelsStreams[hash];
     }
 
-    final s = _doQueryChannels(
+    final newQueryChannelsStream = _doQueryChannels(
       filter: filter,
       sort: sort,
       options: options,
@@ -558,9 +558,9 @@ class Client {
       return _queryChannelsStreams.remove(hash);
     });
 
-    _queryChannelsStreams[hash] = s;
+    _queryChannelsStreams[hash] = newQueryChannelsStream;
 
-    return s;
+    return newQueryChannelsStream;
   }
 
   Stream<List<Channel>> _doQueryChannels({


### PR DESCRIPTION
We save a map of `<String (hash of parameters), Stream<List<Channel>>>`

When a queryChannels call is performed first we compute the hash of the parameters and check if that already exists in our map.

If it exists we return the existing Stream, if it doesn't we perform the real call and add it to the map.

When the call is done we remove the entry of the map.