### PR TITLE
limit channels cids for resync

### DIFF
--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -176,7 +176,7 @@ class OfflineStorage extends _$OfflineStorage {
 
   /// Get the channel cids saved in the offline storage
   Future<List<String>> getChannelCids() async {
-    return select(channels).map((c) => c.cid).get();
+    return (select(channels)..limit(250)).map((c) => c.cid).get();
   }
 
   /// Get channel data by cid

--- a/lib/src/db/offline_storage.dart
+++ b/lib/src/db/offline_storage.dart
@@ -176,7 +176,11 @@ class OfflineStorage extends _$OfflineStorage {
 
   /// Get the channel cids saved in the offline storage
   Future<List<String>> getChannelCids() async {
-    return (select(channels)..limit(250)).map((c) => c.cid).get();
+    return (select(channels)
+          ..orderBy([(c) => OrderingTerm.desc(c._lastMessageAt)])
+          ..limit(250))
+        .map((c) => c.cid)
+        .get();
   }
 
   /// Get channel data by cid


### PR DESCRIPTION
adds a limit to the offline db query because the /sync endpoint accepts max 255 vids