### PR TITLE
change querychannels offline logic

### DIFF
--- a/test/src/client_test.dart
+++ b/test/src/client_test.dart
@@ -120,7 +120,7 @@ void main() {
         when(mockDio.get<String>('/channels', queryParameters: queryParams))
             .thenAnswer((_) async => Response(data: '{}', statusCode: 200));
 
-        await client.queryChannels().toList();
+        await client.queryChannels();
 
         verify(mockDio.get<String>('/channels', queryParameters: queryParams))
             .called(1);
@@ -138,12 +138,12 @@ void main() {
           persistenceEnabled: false,
         );
 
-        final Map<String, dynamic> queryFilter = {
+        final queryFilter = <String, dynamic>{
           "id": {
             "\$in": ["test"],
           },
         };
-        final List<SortOption> sortOptions = [];
+        final sortOptions = <SortOption>[];
         final options = {"state": false, "watch": false, "presence": true};
         final paginationParams = PaginationParams(
           limit: 10,
@@ -164,14 +164,12 @@ void main() {
           return Response(data: '{}', statusCode: 200);
         });
 
-        await client
-            .queryChannels(
-              filter: queryFilter,
-              sort: sortOptions,
-              options: options,
-              paginationParams: paginationParams,
-            )
-            .toList();
+        await client.queryChannels(
+          filter: queryFilter,
+          sort: sortOptions,
+          options: options,
+          paginationParams: paginationParams,
+        );
 
         verify(mockDio.get<String>('/channels', queryParameters: queryParams))
             .called(1);


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

The main problem is that we cannot sort by custom properties, but that's gonna be object of a meeting between all the sdks team leads to discuss a common solution.

The described problem is visible even when the sdk is connected to the internet because during a queryChannels call we return the offline results before querying the backend. This would be nice, but in this case it makes the ui glitch.

This pr modifies this logic, performing the api call and returning the offline data only in the case in which an error occurs.

I know that this is not a definitive solution, but improves the overall user experience while we look for a better solution